### PR TITLE
fix(FP): Suppress parent dependency

### DIFF
--- a/core/src/main/resources/dependencycheck-base-suppression.xml
+++ b/core/src/main/resources/dependencycheck-base-suppression.xml
@@ -2253,6 +2253,14 @@
     </suppress>
     <suppress base="true">
         <notes><![CDATA[
+        FP per issue #5086
+        suppressing the Apache Pluto library that is referenced as a parent dependency
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/javax\.portlet/portlet\-api@.*$</packageUrl>
+        <cpe>cpe:/a:apache:pluto</cpe>
+    </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
         False positive per #1641
         ]]></notes>
         <gav regex="true">^org\.pac4j:pac4j-oidc:.*$</gav>


### PR DESCRIPTION
## Fixes Issue #5086

## Description of Change

* Apache Pluto is defined as the parent in the [pom.xml](https://repo1.maven.org/maven2/javax/portlet/portlet-api/3.0.0/portlet-api-3.0.0.pom) so any vulnerabilities detected in it has no effect on the portlet-api library.

## Have test cases been added to cover the new functionality?

* no